### PR TITLE
allow rendering of markup in titles and abstracts

### DIFF
--- a/totext/templates/abstract.html
+++ b/totext/templates/abstract.html
@@ -9,7 +9,7 @@
         <p>
             <strong>
               {% for title in doc.title %}
-              {{ title }};
+              {{ title|safe }};
               {% endfor %}
             </strong>
             <br>
@@ -18,7 +18,7 @@
               {% endfor %}
             <br>
             <br>
-            {{ doc.abstract }}
+            {{ doc.abstract|safe }}
             <br>
             <br>
             <strong>Publication:</strong> {{ doc.pub }}

--- a/totext/templates/index.html
+++ b/totext/templates/index.html
@@ -74,7 +74,7 @@
                       cited: {{ doc.citation_count }}
                   </div>
                 </div>
-                <strong>{{ doc.title[0] }}</strong>
+                <strong>{{ doc.title[0]|safe }}</strong>
                 <br>
                 {% for auth in doc.author %}
                 {{ auth }};


### PR DESCRIPTION
so, for example, subscripts and superscripts are displayed nicely